### PR TITLE
Update Python Telegram Bot to version 12 and move token to external file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wahBot/config.json

--- a/wahBot/requirements.txt
+++ b/wahBot/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot~=12.1.1

--- a/wahBot/setup.py
+++ b/wahBot/setup.py
@@ -1,28 +1,33 @@
 import telegram
 from telegram.ext import Updater, CommandHandler, MessageHandler, Filters
 import logging
+import json
 
 
-def start(bot, update):
-    bot.send_message(update.message.chat_id, text='WAH')
+def start(update, context):
+    context.bot.send_message(update.message.chat_id, text='WAH')
 
 
-def answer(bot, update):
-    bot.send_message(chat_id=update.message.chat_id, text='WAH')
+def answer(update, context):
+    context.bot.send_message(chat_id=update.message.chat_id, text='WAH')
 
 
-def unknown(bot, update):
-    bot.send_message(chat_id=update.message.chat_id, text="Sorry, I didn't understand that WAH! Speak clearly, bitch!")
+def unknown(update, context):
+    context.bot.send_message(chat_id=update.message.chat_id,
+                     text='Sorry, I didn\'t understand that WAH! Speak clearly, bitch!')
 
 
 def main():
-    ciccia = telegram.Bot(token='123456789:ASDFGHJKLÒZXCVBNMQWcdByHoYDTsMnxDY') # Sample Token
+    with open('config.json', 'r') as fp:
+        config = json.load(fp)
+    ciccia = telegram.Bot(token=config['token'])
     print(ciccia.get_me())
 
-    updater = Updater(token='123456789:ASDFGHJKLÒZXCVBNMQWcdByHoYDTsMnxDY') # Sample Token
+    updater = Updater(token=config['token'], use_context=True)
 
     dispatcher = updater.dispatcher
-    logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
+    logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                        level=logging.INFO)
 
     start_handler = CommandHandler('start', start)
     dispatcher.add_handler(start_handler)


### PR DESCRIPTION
The latest available version of Python Telegram Bot is not compatible with the current code, so I updated it.
Having the Bot token in an external file is better because you can work on the main Python file without accidentally commiting the token online, provided that the config file is in the `.gitignore`.
You can set it up by creating a `config.json` file in the `wahBot` folder, with the token like this:

```
{
  "token": "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
}

```